### PR TITLE
Replaced call to $setValidity with 'required' attr

### DIFF
--- a/angular-re-captcha.js
+++ b/angular-re-captcha.js
@@ -86,14 +86,9 @@ angular.module('reCAPTCHA', []).provider('reCAPTCHA', function() {
 
                 // Reset on Start
                 scope.clear();
-                controller.$setValidity(name, false);
-
-                // Watch for changes to setValidity
-                scope.$watch('ngModel.response', function(response) {
-                    controller.$setValidity(name, (response.length === 0 ? false : true));
-                });
 
                 // Attach model and click handler
+                $compile(angular.element(document.querySelector('input#recaptcha_response_field')).attr('required', ''))(scope);
                 $compile(angular.element(document.querySelector('input#recaptcha_response_field')).attr('ng-model', 'ngModel.response'))(scope);
                 $compile(angular.element(document.querySelector('a#recaptcha_reload_btn')).attr('ng-click', 'clear()'))(scope);
 


### PR DESCRIPTION
Calling controller.$setValidity does nothing.
Adding the 'required' attribute uses built-in behavior and achieves the same without watching the scope.
