### PR TITLE
ngModel.challenge bound using $watch, no $timeout

### DIFF
--- a/angular-re-captcha.js
+++ b/angular-re-captcha.js
@@ -27,7 +27,7 @@ angular.module('reCAPTCHA', []).provider('reCAPTCHA', function() {
     };
 
     this.$get = ['$q', '$rootScope', '$window', '$document', function($q, $rootScope, $window, $document) {
-        var deferred = $q.defer();$
+        var deferred = $q.defer();
 
         if (!$window.Recaptcha) {
             self._createScript($document[0], deferred.resolve);


### PR DESCRIPTION
Fixes #5.

Basically,  we watch for changes on the challenge, and update the model accordingly.
This ensures that we always have the challenge up-to-date in the model _AS LONG_ as the scope has been digested, which will be the case if the user clicks the reload button and then types something in the data-bound response field.

I got rid of $timeout, as using it was the cause of the buggy behavior and it is not used anywhere else.

I'd write a test but, I do not know how to do that.
