### PR TITLE
Check if $window.Recaptcha exists before destroying it

### DIFF
--- a/angular-re-captcha.js
+++ b/angular-re-captcha.js
@@ -60,7 +60,9 @@ angular.module('reCAPTCHA', []).provider('reCAPTCHA', function() {
                 return $window.Recaptcha.reload();
             },
             destroy: function() {
-                $window.Recaptcha.destroy();
+                if ($window.Recaptcha) {
+                    $window.Recaptcha.destroy();
+                }
             }
         };
     }];


### PR DESCRIPTION
In certain situations (like low quality connections) `$window.Recaptcha` can be destroyed before `create` method ends. This bug manifests itself with an error:
```
Cannot read property 'destroy' of undefined
```
This PR adds checking whether `$window.Recaptcha` exists before destroying it.